### PR TITLE
Migrate to premailer for CSS inlining

### DIFF
--- a/mjml/elements/head/mj_style.py
+++ b/mjml/elements/head/mj_style.py
@@ -1,3 +1,4 @@
+import html
 
 from ._head_base import HeadComponent
 
@@ -16,4 +17,4 @@ class MjStyle(HeadComponent):
     def handler(self):
         add = self.context['add']
         inline_attr = 'inlineStyle' if (self.get_attr('inline') == 'inline') else 'style'
-        add(inline_attr, self.getContent())
+        add(inline_attr, html.unescape(self.getContent()))

--- a/mjml/elements/mj_hero.py
+++ b/mjml/elements/mj_hero.py
@@ -100,18 +100,6 @@ class MjHero(BodyComponent):
                 'padding-bottom'        : f'{backgroundRatio}%',
                 'mso-padding-bottom-alt': '0',
             },
-            'hero'               : {
-                'background'         : self.getBackground(),
-                'background-position': self.get_attr('background-position'),
-                'background-repeat'  : 'no-repeat',
-                'border-radius'      : self.get_attr('border-radius'),
-                'padding'            : self.get_attr('padding'),
-                'padding-top'        : self.get_attr('padding-top'),
-                'padding-left'       : self.get_attr('padding-left'),
-                'padding-right'      : self.get_attr('padding-right'),
-                'padding-bottom'     : self.get_attr('padding-bottom'),
-                'vertical-align'     : self.get_attr('vertical-align'),
-            },
             'outlook-table'      : {
                 'width': containerWidth,
             },
@@ -254,7 +242,18 @@ class MjHero(BodyComponent):
     def renderMode(self):
         commonAttributes = {
             'background': self.getAttribute('background-url'),
-            'style': 'hero',
+            'style': {
+                'background'         : self.getBackground(),
+                'background-position': self.get_attr('background-position'),
+                'background-repeat'  : 'no-repeat',
+                'border-radius'      : self.get_attr('border-radius'),
+                'padding'            : self.get_attr('padding'),
+                'padding-top'        : self.get_attr('padding-top'),
+                'padding-left'       : self.get_attr('padding-left'),
+                'padding-right'      : self.get_attr('padding-right'),
+                'padding-bottom'     : self.get_attr('padding-bottom'),
+                'vertical-align'     : self.get_attr('vertical-align'),
+            }
         }
         mode = self.getAttribute('mode')
         if mode == 'fluid-height':
@@ -269,10 +268,12 @@ class MjHero(BodyComponent):
         else:
             height_attr = parse_int(self.getAttribute('height'))
             padding_top = self.getShorthandAttrValue('padding', 'top')
-            paddig_bottom = self.getShorthandAttrValue('padding', 'bottom')
-            height = height_attr - padding_top - paddig_bottom
+            padding_bottom = self.getShorthandAttrValue('padding', 'bottom')
+            height = height_attr - padding_top - padding_bottom
+            style = {**commonAttributes['style'], 'height': f'{height}px'}
+            del commonAttributes['style']
             return f'''
-                <td {self.html_attrs(**commonAttributes, height=height)}>
+                <td {self.html_attrs(**commonAttributes, height=height, style=style)}>
                     {self.renderContent()}
                 </td>
             '''

--- a/mjml/mjml2html.py
+++ b/mjml/mjml2html.py
@@ -244,7 +244,7 @@ def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None,
             include_star_selectors=True,
             css_text=globalDatas.inlineStyle,
             # Premailer applies these attributes for all elements, not just table elements.
-            # This doesn't match MJML upstream. Disable these attributes and implement our own logic.
+            # Disable these attributes and implement our own logic to match MJML upstream.
             disable_basic_attributes=['align', 'bgcolor', 'height', 'valign', 'width'],
         )
         content = inliner.transform(content, pretty_print=False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ testing =
 	lxml
 	PythonicTestcase
 css_inlining =
-	css_inline
+	premailer
 
 
 [options.entry_points]

--- a/tests/testdata/css-inlining-expected.html
+++ b/tests/testdata/css-inlining-expected.html
@@ -74,7 +74,7 @@
 
   </style>
   <style type="text/css">
-    @media only screen and (max-width:480px) {
+    @media only screen and (max-width:479px) {
       table.mj-full-width-mobile {
         width: 100% !important;
       }
@@ -91,14 +91,14 @@
 
 <body style="word-spacing:normal;">
   <div style>
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="box-outlook" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div class="box" style="border: 5px solid red; background-color: blue; margin: 0px auto; max-width: 600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="border: 10px solid red; width: 100%;" width="100%">
         <tbody>
           <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+            <td style="border-radius: 3px; direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
               <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="border-radius: 3px; font-size: 0px; text-align: left; direction: ltr; display: inline-block; vertical-align: top; width: 100%;">
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
@@ -107,7 +107,7 @@
                           <tbody>
                             <tr>
                               <td style="width:100px;">
-                                <img height="auto" src="/assets/img/logo-small.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100">
+                                <img src="/assets/img/logo-small.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100" height="auto">
                               </td>
                             </tr>
                           </tbody>
@@ -123,7 +123,7 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" class="box" style="border: 5px solid red; font-size: 0px; padding: 10px 25px; word-break: break-word;">
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                         <div style="font-family:helvetica;font-size:20px;line-height:1;text-align:left;color:#F45E43;">Hello World</div>
                       </td>
                     </tr>

--- a/tests/testdata/css-inlining.mjml
+++ b/tests/testdata/css-inlining.mjml
@@ -3,18 +3,26 @@
     <mj-style inline="inline">
       .box {
         border: 5px solid red;
+        background-color: blue;
+      }
+      .box > table {
+        border: 10px solid red;
+      }
+      .box > table > tbody > tr > td,
+      .box > table > tbody > tr > td > div {
+        border-radius: 3px;
       }
     </mj-style>
   </mj-head>
   <mj-body>
-    <mj-section>
+    <mj-section css-class="box">
       <mj-column>
 
         <mj-image width="100px" src="/assets/img/logo-small.png"></mj-image>
 
         <mj-divider border-color="#F45E43"></mj-divider>
 
-        <mj-text css-class="box" font-size="20px" color="#F45E43" font-family="helvetica">Hello World</mj-text>
+        <mj-text font-size="20px" color="#F45E43" font-family="helvetica">Hello World</mj-text>
 
       </mj-column>
     </mj-section>

--- a/tests/testdata/hello-world-expected.html
+++ b/tests/testdata/hello-world-expected.html
@@ -74,7 +74,7 @@
 
   </style>
   <style type="text/css">
-    @media only screen and (max-width:480px) {
+    @media only screen and (max-width:479px) {
       table.mj-full-width-mobile {
         width: 100% !important;
       }
@@ -107,7 +107,7 @@
                           <tbody>
                             <tr>
                               <td style="width:100px;">
-                                <img height="auto" src="/assets/img/logo-small.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100" />
+                                <img src="/assets/img/logo-small.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100" height="auto" />
                               </td>
                             </tr>
                           </tbody>

--- a/tests/testdata/mj-carousel-expected.html
+++ b/tests/testdata/mj-carousel-expected.html
@@ -80,7 +80,7 @@
       user-select: none;
     }
 
-    .mj-carousel-07fcbd59c1637f6b-icons-cell {
+    .mj-carousel-f3201d991bba8113-icons-cell {
       display: table-cell !important;
       width: 44px !important;
     }
@@ -97,32 +97,32 @@
       touch-action: manipulation;
     }
 
-    .mj-carousel-07fcbd59c1637f6b-radio:checked+.mj-carousel-content .mj-carousel-image,
-    .mj-carousel-07fcbd59c1637f6b-radio:checked+*+.mj-carousel-content .mj-carousel-image,
-    .mj-carousel-07fcbd59c1637f6b-radio:checked+*+*+.mj-carousel-content .mj-carousel-image {
+    .mj-carousel-f3201d991bba8113-radio:checked+.mj-carousel-content .mj-carousel-image,
+    .mj-carousel-f3201d991bba8113-radio:checked+*+.mj-carousel-content .mj-carousel-image,
+    .mj-carousel-f3201d991bba8113-radio:checked+*+*+.mj-carousel-content .mj-carousel-image {
       display: none !important;
     }
 
-    .mj-carousel-07fcbd59c1637f6b-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-image-1,
-    .mj-carousel-07fcbd59c1637f6b-radio-2:checked+*+.mj-carousel-content .mj-carousel-image-2,
-    .mj-carousel-07fcbd59c1637f6b-radio-3:checked+.mj-carousel-content .mj-carousel-image-3 {
+    .mj-carousel-f3201d991bba8113-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-image-1,
+    .mj-carousel-f3201d991bba8113-radio-2:checked+*+.mj-carousel-content .mj-carousel-image-2,
+    .mj-carousel-f3201d991bba8113-radio-3:checked+.mj-carousel-content .mj-carousel-image-3 {
       display: block !important;
     }
 
     .mj-carousel-previous-icons,
     .mj-carousel-next-icons,
-    .mj-carousel-07fcbd59c1637f6b-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-next-2,
-    .mj-carousel-07fcbd59c1637f6b-radio-2:checked+*+.mj-carousel-content .mj-carousel-next-3,
-    .mj-carousel-07fcbd59c1637f6b-radio-3:checked+.mj-carousel-content .mj-carousel-next-1,
-    .mj-carousel-07fcbd59c1637f6b-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-previous-3,
-    .mj-carousel-07fcbd59c1637f6b-radio-2:checked+*+.mj-carousel-content .mj-carousel-previous-1,
-    .mj-carousel-07fcbd59c1637f6b-radio-3:checked+.mj-carousel-content .mj-carousel-previous-2 {
+    .mj-carousel-f3201d991bba8113-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-next-2,
+    .mj-carousel-f3201d991bba8113-radio-2:checked+*+.mj-carousel-content .mj-carousel-next-3,
+    .mj-carousel-f3201d991bba8113-radio-3:checked+.mj-carousel-content .mj-carousel-next-1,
+    .mj-carousel-f3201d991bba8113-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-previous-3,
+    .mj-carousel-f3201d991bba8113-radio-2:checked+*+.mj-carousel-content .mj-carousel-previous-1,
+    .mj-carousel-f3201d991bba8113-radio-3:checked+.mj-carousel-content .mj-carousel-previous-2 {
       display: block !important;
     }
 
-    .mj-carousel-07fcbd59c1637f6b-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-07fcbd59c1637f6b-thumbnail-1,
-    .mj-carousel-07fcbd59c1637f6b-radio-2:checked+*+.mj-carousel-content .mj-carousel-07fcbd59c1637f6b-thumbnail-2,
-    .mj-carousel-07fcbd59c1637f6b-radio-3:checked+.mj-carousel-content .mj-carousel-07fcbd59c1637f6b-thumbnail-3 {
+    .mj-carousel-f3201d991bba8113-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-f3201d991bba8113-thumbnail-1,
+    .mj-carousel-f3201d991bba8113-radio-2:checked+*+.mj-carousel-content .mj-carousel-f3201d991bba8113-thumbnail-2,
+    .mj-carousel-f3201d991bba8113-radio-3:checked+.mj-carousel-content .mj-carousel-f3201d991bba8113-thumbnail-3 {
       border-color: #cccccc !important;
     }
 
@@ -131,9 +131,9 @@
       display: none !important;
     }
 
-    .mj-carousel-07fcbd59c1637f6b-thumbnail:hover+*+*+.mj-carousel-main .mj-carousel-image,
-    .mj-carousel-07fcbd59c1637f6b-thumbnail:hover+*+.mj-carousel-main .mj-carousel-image,
-    .mj-carousel-07fcbd59c1637f6b-thumbnail:hover+.mj-carousel-main .mj-carousel-image {
+    .mj-carousel-f3201d991bba8113-thumbnail:hover+*+*+.mj-carousel-main .mj-carousel-image,
+    .mj-carousel-f3201d991bba8113-thumbnail:hover+*+.mj-carousel-main .mj-carousel-image,
+    .mj-carousel-f3201d991bba8113-thumbnail:hover+.mj-carousel-main .mj-carousel-image {
       display: none !important;
     }
 
@@ -141,9 +141,9 @@
       border-color: #fead0d !important;
     }
 
-    .mj-carousel-07fcbd59c1637f6b-thumbnail-1:hover+*+*+.mj-carousel-main .mj-carousel-image-1,
-    .mj-carousel-07fcbd59c1637f6b-thumbnail-2:hover+*+.mj-carousel-main .mj-carousel-image-2,
-    .mj-carousel-07fcbd59c1637f6b-thumbnail-3:hover+.mj-carousel-main .mj-carousel-image-3 {
+    .mj-carousel-f3201d991bba8113-thumbnail-1:hover+*+*+.mj-carousel-main .mj-carousel-image-1,
+    .mj-carousel-f3201d991bba8113-thumbnail-2:hover+*+.mj-carousel-main .mj-carousel-image-2,
+    .mj-carousel-f3201d991bba8113-thumbnail-3:hover+.mj-carousel-main .mj-carousel-image-3 {
       display: block !important;
     }
 
@@ -166,13 +166,13 @@
 
     @media screen yahoo {
 
-      .mj-carousel-07fcbd59c1637f6b-icons-cell,
+      .mj-carousel-f3201d991bba8113-icons-cell,
       .mj-carousel-previous-icons,
       .mj-carousel-next-icons {
         display: none !important;
       }
 
-      .mj-carousel-07fcbd59c1637f6b-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-07fcbd59c1637f6b-thumbnail-1 {
+      .mj-carousel-f3201d991bba8113-radio-1:checked+*+*+.mj-carousel-content .mj-carousel-f3201d991bba8113-thumbnail-1 {
         border-color: transparent;
       }
     }
@@ -198,37 +198,37 @@
                       <td align="center" style="font-size:0px;word-break:break-word;">
                         <!--[if !mso><!-->
                         <div class="mj-carousel">
-                          <input class="mj-carousel-radio mj-carousel-07fcbd59c1637f6b-radio mj-carousel-07fcbd59c1637f6b-radio-1" checked="checked" type="radio" name="mj-carousel-radio-07fcbd59c1637f6b" id="mj-carousel-07fcbd59c1637f6b-radio-1" style="display:none;mso-hide:all;" />
-                          <input class="mj-carousel-radio mj-carousel-07fcbd59c1637f6b-radio mj-carousel-07fcbd59c1637f6b-radio-2" type="radio" name="mj-carousel-radio-07fcbd59c1637f6b" id="mj-carousel-07fcbd59c1637f6b-radio-2" style="display:none;mso-hide:all;" />
-                          <input class="mj-carousel-radio mj-carousel-07fcbd59c1637f6b-radio mj-carousel-07fcbd59c1637f6b-radio-3" type="radio" name="mj-carousel-radio-07fcbd59c1637f6b" id="mj-carousel-07fcbd59c1637f6b-radio-3" style="display:none;mso-hide:all;" />
-                          <div class="mj-carousel-content mj-carousel-07fcbd59c1637f6b-content" style="display:table;width:100%;table-layout:fixed;text-align:center;font-size:0px;">
-                            <a style="border:2px solid transparent;border-radius:6px;display:inline-block;overflow:hidden;width:110px;" href="#1" target="_blank" class="mj-carousel-thumbnail mj-carousel-07fcbd59c1637f6b-thumbnail mj-carousel-07fcbd59c1637f6b-thumbnail-1 ">
-                              <label for="mj-carousel-07fcbd59c1637f6b-radio-1">
+                          <input class="mj-carousel-radio mj-carousel-f3201d991bba8113-radio mj-carousel-f3201d991bba8113-radio-1" checked="checked" type="radio" name="mj-carousel-radio-f3201d991bba8113" id="mj-carousel-f3201d991bba8113-radio-1" style="display:none;mso-hide:all;" />
+                          <input class="mj-carousel-radio mj-carousel-f3201d991bba8113-radio mj-carousel-f3201d991bba8113-radio-2" type="radio" name="mj-carousel-radio-f3201d991bba8113" id="mj-carousel-f3201d991bba8113-radio-2" style="display:none;mso-hide:all;" />
+                          <input class="mj-carousel-radio mj-carousel-f3201d991bba8113-radio mj-carousel-f3201d991bba8113-radio-3" type="radio" name="mj-carousel-radio-f3201d991bba8113" id="mj-carousel-f3201d991bba8113-radio-3" style="display:none;mso-hide:all;" />
+                          <div class="mj-carousel-content mj-carousel-f3201d991bba8113-content" style="display:table;width:100%;table-layout:fixed;text-align:center;font-size:0px;">
+                            <a style="border:2px solid transparent;border-radius:6px;display:inline-block;overflow:hidden;width:110px;" href="#1" target="_blank" class="mj-carousel-thumbnail mj-carousel-f3201d991bba8113-thumbnail mj-carousel-f3201d991bba8113-thumbnail-1 ">
+                              <label for="mj-carousel-f3201d991bba8113-radio-1">
                                 <img style="display:block;width:100%;height:auto;" src="https://www.mailjet.com/wp-content/uploads/2016/11/ecommerce-guide.jpg" width="110" />
                               </label>
                             </a>
-                            <a style="border:2px solid transparent;border-radius:6px;display:inline-block;overflow:hidden;width:110px;" href="#2" target="_blank" class="mj-carousel-thumbnail mj-carousel-07fcbd59c1637f6b-thumbnail mj-carousel-07fcbd59c1637f6b-thumbnail-2 ">
-                              <label for="mj-carousel-07fcbd59c1637f6b-radio-2">
+                            <a style="border:2px solid transparent;border-radius:6px;display:inline-block;overflow:hidden;width:110px;" href="#2" target="_blank" class="mj-carousel-thumbnail mj-carousel-f3201d991bba8113-thumbnail mj-carousel-f3201d991bba8113-thumbnail-2 ">
+                              <label for="mj-carousel-f3201d991bba8113-radio-2">
                                 <img style="display:block;width:100%;height:auto;" src="https://www.mailjet.com/wp-content/uploads/2016/09/3@1x.png" width="110" />
                               </label>
                             </a>
-                            <a style="border:2px solid transparent;border-radius:6px;display:inline-block;overflow:hidden;width:110px;" href="#3" target="_blank" class="mj-carousel-thumbnail mj-carousel-07fcbd59c1637f6b-thumbnail mj-carousel-07fcbd59c1637f6b-thumbnail-3 ">
-                              <label for="mj-carousel-07fcbd59c1637f6b-radio-3">
+                            <a style="border:2px solid transparent;border-radius:6px;display:inline-block;overflow:hidden;width:110px;" href="#3" target="_blank" class="mj-carousel-thumbnail mj-carousel-f3201d991bba8113-thumbnail mj-carousel-f3201d991bba8113-thumbnail-3 ">
+                              <label for="mj-carousel-f3201d991bba8113-radio-3">
                                 <img style="display:block;width:100%;height:auto;" src="https://www.mailjet.com/wp-content/uploads/2016/09/1@1x.png" width="110" />
                               </label>
                             </a>
                             <table style="caption-side:top;display:table-caption;table-layout:fixed;width:100%;" border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation" class="mj-carousel-main">
                               <tbody>
                                 <tr>
-                                  <td class="mj-carousel-07fcbd59c1637f6b-icons-cell" style="font-size:0px;display:none;mso-hide:all;padding:0px;">
+                                  <td class="mj-carousel-f3201d991bba8113-icons-cell" style="font-size:0px;display:none;mso-hide:all;padding:0px;">
                                     <div class="mj-carousel-previous-icons" style="display:none;mso-hide:all;">
-                                      <label for="mj-carousel-07fcbd59c1637f6b-radio-1" class="mj-carousel-previous mj-carousel-previous-1">
+                                      <label for="mj-carousel-f3201d991bba8113-radio-1" class="mj-carousel-previous mj-carousel-previous-1">
                                         <img src="https://i.imgur.com/xTh3hln.png" alt="previous" style="display:block;width:44px;height:auto;" width="44" />
                                       </label>
-                                      <label for="mj-carousel-07fcbd59c1637f6b-radio-2" class="mj-carousel-previous mj-carousel-previous-2">
+                                      <label for="mj-carousel-f3201d991bba8113-radio-2" class="mj-carousel-previous mj-carousel-previous-2">
                                         <img src="https://i.imgur.com/xTh3hln.png" alt="previous" style="display:block;width:44px;height:auto;" width="44" />
                                       </label>
-                                      <label for="mj-carousel-07fcbd59c1637f6b-radio-3" class="mj-carousel-previous mj-carousel-previous-3">
+                                      <label for="mj-carousel-f3201d991bba8113-radio-3" class="mj-carousel-previous mj-carousel-previous-3">
                                         <img src="https://i.imgur.com/xTh3hln.png" alt="previous" style="display:block;width:44px;height:auto;" width="44" />
                                       </label>
                                     </div>
@@ -246,15 +246,15 @@
                                       </div>
                                     </div>
                                   </td>
-                                  <td class="mj-carousel-07fcbd59c1637f6b-icons-cell" style="font-size:0px;display:none;mso-hide:all;padding:0px;">
+                                  <td class="mj-carousel-f3201d991bba8113-icons-cell" style="font-size:0px;display:none;mso-hide:all;padding:0px;">
                                     <div class="mj-carousel-next-icons" style="display:none;mso-hide:all;">
-                                      <label for="mj-carousel-07fcbd59c1637f6b-radio-1" class="mj-carousel-next mj-carousel-next-1">
+                                      <label for="mj-carousel-f3201d991bba8113-radio-1" class="mj-carousel-next mj-carousel-next-1">
                                         <img src="https://i.imgur.com/os7o9kz.png" alt="next" style="display:block;width:44px;height:auto;" width="44" />
                                       </label>
-                                      <label for="mj-carousel-07fcbd59c1637f6b-radio-2" class="mj-carousel-next mj-carousel-next-2">
+                                      <label for="mj-carousel-f3201d991bba8113-radio-2" class="mj-carousel-next mj-carousel-next-2">
                                         <img src="https://i.imgur.com/os7o9kz.png" alt="next" style="display:block;width:44px;height:auto;" width="44" />
                                       </label>
-                                      <label for="mj-carousel-07fcbd59c1637f6b-radio-3" class="mj-carousel-next mj-carousel-next-3">
+                                      <label for="mj-carousel-f3201d991bba8113-radio-3" class="mj-carousel-next mj-carousel-next-3">
                                         <img src="https://i.imgur.com/os7o9kz.png" alt="next" style="display:block;width:44px;height:auto;" width="44" />
                                       </label>
                                     </div>

--- a/tests/testdata/mj-group-expected.html
+++ b/tests/testdata/mj-group-expected.html
@@ -91,7 +91,7 @@
 
   </style>
   <style type="text/css">
-    @media only screen and (max-width:480px) {
+    @media only screen and (max-width:479px) {
       table.mj-full-width-mobile {
         width: 100% !important;
       }
@@ -126,7 +126,7 @@
                             <tbody>
                               <tr>
                                 <td style="width:137px;">
-                                  <img height="185" src="https://mjml.io/assets/img/easy-and-quick.png" style="border:0;display:block;outline:none;text-decoration:none;height:185px;width:100%;font-size:13px;" width="137" />
+                                  <img src="https://mjml.io/assets/img/easy-and-quick.png" style="border:0;display:block;outline:none;text-decoration:none;height:185px;width:100%;font-size:13px;" width="137" height="185" />
                                 </td>
                               </tr>
                             </tbody>
@@ -154,7 +154,7 @@
                             <tbody>
                               <tr>
                                 <td style="width:166px;">
-                                  <img height="185" src="https://mjml.io/assets/img/responsive.png" style="border:0;display:block;outline:none;text-decoration:none;height:185px;width:100%;font-size:13px;" width="166" />
+                                  <img src="https://mjml.io/assets/img/responsive.png" style="border:0;display:block;outline:none;text-decoration:none;height:185px;width:100%;font-size:13px;" width="166" height="185" />
                                 </td>
                               </tr>
                             </tbody>

--- a/tests/testdata/mj-hero-fixed-expected.html
+++ b/tests/testdata/mj-hero-fixed-expected.html
@@ -77,7 +77,7 @@
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
         <tbody>
           <tr style="vertical-align:top;">
-            <td background="https://cloud.githubusercontent.com/assets/1830348/15354890/1442159a-1cf0-11e6-92b1-b861dadf1750.jpg" style="background:#2a3448 url('https://cloud.githubusercontent.com/assets/1830348/15354890/1442159a-1cf0-11e6-92b1-b861dadf1750.jpg') no-repeat center center / cover;background-position:center center;background-repeat:no-repeat;padding:100px 0px;vertical-align:top;" height="269">
+            <td background="https://cloud.githubusercontent.com/assets/1830348/15354890/1442159a-1cf0-11e6-92b1-b861dadf1750.jpg" style="background:#2a3448 url('https://cloud.githubusercontent.com/assets/1830348/15354890/1442159a-1cf0-11e6-92b1-b861dadf1750.jpg') no-repeat center center / cover;background-position:center center;background-repeat:no-repeat;padding:100px 0px;vertical-align:top;height:269px;" height="269">
               <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" style="width:600px;" width="600" ><tr><td style=""><![endif]-->
               <div class="mj-hero-content" style="margin:0px auto;">
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;margin:0px;">

--- a/tests/testdata/mj-image-with-empty-alt-attribute-expected.html
+++ b/tests/testdata/mj-image-with-empty-alt-attribute-expected.html
@@ -74,7 +74,7 @@
 
   </style>
   <style type="text/css">
-    @media only screen and (max-width:480px) {
+    @media only screen and (max-width:479px) {
       table.mj-full-width-mobile {
         width: 100% !important;
       }
@@ -107,7 +107,7 @@
                           <tbody>
                             <tr>
                               <td style="width:100px;">
-                                <img alt="" height="100" src="https://picsum.photos/100" style="border:0;display:block;outline:none;text-decoration:none;height:100px;width:100%;font-size:13px;" width="100" />
+                                <img alt="" src="https://picsum.photos/100" style="border:0;display:block;outline:none;text-decoration:none;height:100px;width:100%;font-size:13px;" width="100" height="100" />
                               </td>
                             </tr>
                           </tbody>

--- a/tests/testdata/mj-image-with-href-expected.html
+++ b/tests/testdata/mj-image-with-href-expected.html
@@ -74,7 +74,7 @@
 
   </style>
   <style type="text/css">
-    @media only screen and (max-width:480px) {
+    @media only screen and (max-width:479px) {
       table.mj-full-width-mobile {
         width: 100% !important;
       }
@@ -108,7 +108,7 @@
                             <tr>
                               <td style="width:100px;">
                                 <a href="http://foo.example" target="_blank">
-                                  <img height="100" src="https://picsum.photos/100" style="border:0;display:block;outline:none;text-decoration:none;height:100px;width:100%;font-size:13px;" width="100" />
+                                  <img src="https://picsum.photos/100" style="border:0;display:block;outline:none;text-decoration:none;height:100px;width:100%;font-size:13px;" width="100" height="100" />
                                 </a>
                               </td>
                             </tr>

--- a/tests/testdata/mj-navbar-expected.html
+++ b/tests/testdata/mj-navbar-expected.html
@@ -87,7 +87,7 @@
       visibility: visible !important;
     }
 
-    @media only screen and (max-width:480px) {
+    @media only screen and (max-width:479px) {
       .mj-menu-checkbox[type="checkbox"]~.mj-inline-links {
         display: none !important;
       }
@@ -133,10 +133,10 @@
                     <tr>
                       <td align="center" style="font-size:0px;word-break:break-word;">
                         <!--[if !mso><!-->
-                        <input type="checkbox" id="602e2a2866422871" class="mj-menu-checkbox" style="display:none !important; max-height:0; visibility:hidden;" />
+                        <input type="checkbox" id="1f9a9d39405d3c67" class="mj-menu-checkbox" style="display:none !important; max-height:0; visibility:hidden;" />
                         <!--<![endif]-->
                         <div class="mj-menu-trigger" style="display:none;max-height:0px;max-width:0px;font-size:0px;overflow:hidden;">
-                          <label for="602e2a2866422871" class="mj-menu-label" style="display:block;cursor:pointer;mso-hide:all;-moz-user-select:none;user-select:none;color:#ffffff;font-size:30px;font-family:Ubuntu, Helvetica, Arial, sans-serif;text-transform:uppercase;text-decoration:none;line-height:30px;padding:10px;" align="center">
+                          <label for="1f9a9d39405d3c67" class="mj-menu-label" style="display:block;cursor:pointer;mso-hide:all;-moz-user-select:none;user-select:none;color:#ffffff;font-size:30px;font-family:Ubuntu, Helvetica, Arial, sans-serif;text-transform:uppercase;text-decoration:none;line-height:30px;padding:10px;" align="center">
                             <span class="mj-menu-icon-open" style="mso-hide:all;"> &#9776; </span>
                             <span class="mj-menu-icon-close" style="display:none;mso-hide:all;"> &#8855; </span>
                           </label>

--- a/tests/upstream_alignment_test.py
+++ b/tests/upstream_alignment_test.py
@@ -85,7 +85,7 @@ class UpstreamAlignmentTest(TestCase):
 
     def test_can_use_css_inlining(self):
         try:
-            import css_inline  # noqa: unused-import
+            import premailer  # noqa: unused-import
         except ImportError:
             raise SkipTest('"css_inline" not installed')
         test_id = 'css-inlining'


### PR DESCRIPTION
This appears to be working except for us implementing our own version of Juice's `applyAttributesTableElements`. We can probably just make premailer a required dependency too.