### PR TITLE
CSS improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 0.10.0 (?)
 ------------------
 
+- fix CSS child selectors
+- disable loading remote stylesheets
 - require css-inline 0.11.x for performance improvements
 - drop css-inline Python 3.6 support
 - fix exception when processing an `mj-section` with `background-size` (reported by Thomas Handorf)

--- a/mjml/mjml2html.py
+++ b/mjml/mjml2html.py
@@ -115,7 +115,7 @@ def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None,
             classes = ignore_empty(attributes.get('mj-class', '').split(' '))
 
             # upstream parses text contents (+ comments) in mjml-parser-xml/index.js
-            content = _mjml.decode_contents()
+            content = _mjml.decode_contents(formatter=None)
 
             attributesClasses = {}
             for css_class in classes:
@@ -212,7 +212,7 @@ def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None,
                 for element in contentSoup.select(selector):
                     element[attrName] = value or ''
 
-        content = contentSoup.decode_contents()
+        content = contentSoup.decode_contents(formatter=None)
 
     content = skeleton(
         content=content,
@@ -235,6 +235,7 @@ def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None,
             inline_style_tags=False,
             keep_link_tags=True,
             keep_style_tags=True,
+            load_remote_stylesheets=False,
         )
         content = inliner.inline(content)
 

--- a/tests/testdata/css-inlining-expected.html
+++ b/tests/testdata/css-inlining-expected.html
@@ -124,7 +124,7 @@
                     </tr>
                     <tr>
                       <td align="left" class="box" style="border: 5px solid red; font-size: 0px; padding: 10px 25px; word-break: break-word;">
-                        <div style="font-family:helvetica;font-size:20px;line-height:1;text-align:left;color:#F45E43;">Hello World</div>
+                        <div style="font-family:helvetica;font-size:20px;line-height:1;text-align:left;color:#F45E43;"><span style="border: 3px solid blue;"> &lt; Hello World &gt; </span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/tests/testdata/css-inlining.mjml
+++ b/tests/testdata/css-inlining.mjml
@@ -4,6 +4,9 @@
       .box {
         border: 5px solid red;
       }
+      .box > div > span {
+        border: 3px solid blue;
+      }
     </mj-style>
   </mj-head>
   <mj-body>
@@ -14,7 +17,11 @@
 
         <mj-divider border-color="#F45E43"></mj-divider>
 
-        <mj-text css-class="box" font-size="20px" color="#F45E43" font-family="helvetica">Hello World</mj-text>
+        <mj-text css-class="box" font-size="20px" color="#F45E43" font-family="helvetica">
+          <span>
+            &lt; Hello World &gt;
+          </span>
+        </mj-text>
 
       </mj-column>
     </mj-section>


### PR DESCRIPTION
- Don't escape HTML when decoding (fixes #44)
- Don't load remote stylesheets (aligns with upstream MJML functionality)