### PR TITLE
Improve typing

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,56 @@
+name: typecheck
+
+on:
+  push:
+    branches:
+      - main
+      - typing
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+        option: ["", "--strict"]
+        include:
+          - python-version: "3.8"
+            version-name: "3.8"
+          - python-version: "3.9"
+            version-name: "3.9"
+          - python-version: "3.10"
+            version-name: "3.10"
+          - python-version: "3.11"
+            version-name: "3.11"
+          - python-version: "3.12"
+            version-name: "3.12"
+          - python-version: "pypy-3.9"
+            version-name: "3.9"
+          - python-version: "pypy-3.10"
+            version-name: "3.10"
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # TODO typing: fix
+      - name: Install dependencies
+        run: |
+          pip install "mypy==1.10.1"
+          pip install -e .[testing]
+          pip install -e .[css_inlining]
+          pip install types-docopt types-beautifulsoup4
+
+      - name: Run mypy ${{ matrix.option }}
+        run: |
+          mypy ${{ matrix.option }} --python-version="${{ matrix.version-name }}" mjml
+        if: ${{ !cancelled() }}

--- a/mjml/_types.py
+++ b/mjml/_types.py
@@ -1,0 +1,4 @@
+import typing as t
+
+
+_Direction = t.Literal["top", "bottom", "left", "right"]

--- a/mjml/core/api.py
+++ b/mjml/core/api.py
@@ -93,5 +93,8 @@ class Component:
         return self.attrs.get(name)
     getAttribute = get_attr
 
+    def handler(self) -> t.Optional[str]:
+        return None
+
     def render(self) -> str:
         return ''

--- a/mjml/core/api.py
+++ b/mjml/core/api.py
@@ -1,5 +1,4 @@
-
-from dotmap import DotMap
+import typing as t
 
 from ..lib import merge_dicts
 from .registry import components
@@ -7,7 +6,8 @@ from .registry import components
 
 __all__ = ['initComponent', 'Component']
 
-def initComponent(name, **initialDatas):
+def initComponent(name: t.Optional[str],
+                  **initialDatas: t.Any) -> t.Optional["Component"]:
     if name is None:
         return None
     component_cls = components[name]
@@ -24,15 +24,22 @@ def initComponent(name, **initialDatas):
 
 
 class Component:
+    component_name: t.ClassVar[str]
+
     # LATER: not sure upstream also passes tagName, makes code easier for us
-    def __init__(self, *, attributes=None, children=(), content='', context=None,
-                 props=None, globalAttributes=None, headStyle=None, tagName=None):
+    def __init__(self, *, attributes=None, children=(), content: str='',
+                 context: t.Optional[t.Dict[str, t.Any]]=None,
+                 props: t.Optional[t.Dict[str, t.Any]]=None,
+                 globalAttributes: t.Optional[t.Dict[str, t.Any]]=None,
+                 headStyle: t.Optional[t.Any]=None,
+                 tagName: t.Optional[str]=None) -> None:
         self.children = list(children)
         self.content = content
-        self.context = context
+        # TODO typing: verify that this is the intent
+        self.context = context or dict()
         self.tagName = tagName
 
-        self.props = DotMap(merge_dicts(props, {'children': children, 'content': content}))
+        self.props = merge_dicts(props or {}, {'children': children, 'content': content})
 
         # upstream also checks "self.allowed_attrs"
         self.attrs = merge_dicts(
@@ -46,26 +53,26 @@ class Component:
             self.headStyle = headStyle
 
     @classmethod
-    def getTagName(cls):
+    def getTagName(cls) -> str:
         cls_name = cls.__name__
         return cls_name
 
     @classmethod
-    def isRawElement(cls):
+    def isRawElement(cls) -> bool:
         cls_value = getattr(cls, 'rawElement', None)
         return bool(cls_value)
 
     # js: static defaultAttributes
     @classmethod
-    def default_attrs(cls):
+    def default_attrs(cls) -> t.Dict[str, t.Any]:
         return {}
 
     # js: static allowedAttributes
     @classmethod
-    def allowed_attrs(cls):
-        return ()
+    def allowed_attrs(cls) -> t.Dict[str, str]:
+        return {}
 
-    def getContent(self):
+    def getContent(self) -> str:
         # Actually "self.content" should not be None but sometimes it is
         # (probably due to bugs in this Python port). This special guard
         # clause is the final fix to render the "welcome-email.mjml" from
@@ -74,11 +81,11 @@ class Component:
             return ''
         return self.content.strip()
 
-    def getChildContext(self):
+    def getChildContext(self) -> t.Dict[str, t.Any]:
         return self.context
 
     # js: getAttribute(name)
-    def get_attr(self, name, *, missing_ok=False):
+    def get_attr(self, name: str, *, missing_ok: bool=False) -> t.Optional[t.Any]:
         is_allowed_attr = name in self.allowed_attrs()
         is_default_attr = name in self.default_attrs()
         if not missing_ok and (not is_allowed_attr) and (not is_default_attr):
@@ -86,5 +93,5 @@ class Component:
         return self.attrs.get(name)
     getAttribute = get_attr
 
-    def render(self):
+    def render(self) -> str:
         return ''

--- a/mjml/elements/_base.py
+++ b/mjml/elements/_base.py
@@ -102,8 +102,10 @@ class BodyComponent(Component):
         style_str = ';'.join(style_attr_strs)
         return style_str
 
-    def renderChildren(self, childrens=None, props=None, renderer=None,
-                       attributes=None, rawXML=False):
+    # TODO typing: finish rest of type annotations
+    def renderChildren(self, childrens=None, props=None,
+                       renderer: t.Optional[t.Callable[[Component], str]]=None,
+                       attributes=None, rawXML=False) -> str:
         if not props:
             props = {}
         if not renderer:
@@ -128,8 +130,8 @@ class BodyComponent(Component):
         #  child => !find(rawComponents, c => c.getTagName() === child.tagName),
         #).length
         raw_tag_names = set()
-        for tag_name, component in components.items():
-            if component.isRawElement():
+        for tag_name, component_cls in components.items():
+            if component_cls.isRawElement():
                 raw_tag_names.add(tag_name)
         is_raw_element = lambda c: (c['tagName'] in raw_tag_names)
 

--- a/mjml/elements/_base.py
+++ b/mjml/elements/_base.py
@@ -18,7 +18,7 @@ __all__ = [
 
 class BodyComponent(Component):
     def render(self) -> str:
-        raise NotImplementedError(f'{self.__cls__.__name__} should override ".render()"')
+        raise NotImplementedError(f'{self.__class__.__name__} should override ".render()"')
 
     def getShorthandAttrValue(self,
                               attribute: str, direction: "_Direction",

--- a/mjml/elements/_base.py
+++ b/mjml/elements/_base.py
@@ -1,6 +1,4 @@
-
-
-from dotmap import DotMap
+import typing as t
 
 from ..core import Component, initComponent
 from ..core.registry import components
@@ -34,19 +32,19 @@ class BodyComponent(Component):
         border = self.getAttribute('border')
         return borderParser(borderDirection or border or '0')
 
-    def getBoxWidths(self):
+    def getBoxWidths(self) -> t.Dict[str, t.Any]:
         containerWidth = self.context['containerWidth']
         parsedWidth = strip_unit(containerWidth)
         get_padding = lambda d: self.getShorthandAttrValue('padding', d)
         paddings = get_padding('right') + get_padding('left')
         borders = self.getShorthandBorderValue('right') + self.getShorthandBorderValue('left')
 
-        return DotMap({
+        return {
             'totalWidth': parsedWidth,
             'borders'   : borders,
             'paddings'  : paddings,
             'box'       : parsedWidth - paddings - borders,
-        })
+        }
 
     # js: htmlAttributes(attributes)
     def html_attrs(self, **attrs):
@@ -100,7 +98,7 @@ class BodyComponent(Component):
             renderer = lambda component: component.render()
         if not attributes:
             attributes = {}
-        childrens = childrens or self.props.children
+        childrens = childrens or self.props.get("children")
 
         if rawXML:
             # return childrens.map(child => jsonToXML(child)).join('\n')

--- a/mjml/elements/head/_head_base.py
+++ b/mjml/elements/head/_head_base.py
@@ -25,5 +25,5 @@ class HeadComponent(Component):
                 return component.render()
             return None
 
-        childrens = self.props.children
+        childrens = self.props.get("children")
         return tuple(map(handle_children, childrens))

--- a/mjml/elements/head/_head_base.py
+++ b/mjml/elements/head/_head_base.py
@@ -1,12 +1,15 @@
+import typing as t
 
 from mjml.core import Component, initComponent
 
 
 __all__ = ['HeadComponent']
 
+
 class HeadComponent(Component):
+    # TODO typing: figure out proper type annotations
     def handlerChildren(self):
-        def handle_children(children):
+        def handle_children(children: t.Dict[str, t.Any]) -> t.Optional[str]:
             tagName = children['tagName']
             component = initComponent(
                 name = tagName,

--- a/mjml/elements/head/mj_attributes.py
+++ b/mjml/elements/head/mj_attributes.py
@@ -1,3 +1,6 @@
+import typing as t
+
+import typing_extensions as te
 
 from mjml.helpers import omit
 
@@ -6,12 +9,15 @@ from ._head_base import HeadComponent
 
 __all__ = ['MjAttributes']
 
-class MjAttributes(HeadComponent):
-    component_name = 'mj-attributes'
 
-    def handler(self):
+class MjAttributes(HeadComponent):
+    component_name: t.ClassVar[str] = 'mj-attributes'
+
+    @te.override
+    def handler(self) -> None:
         add = self.context['add']
-        _children = self.props.get("children")
+        if (_children := self.props.get("children")) is None:
+            return None
 
         for child in _children:
             tagName = child['tagName']

--- a/mjml/elements/head/mj_attributes.py
+++ b/mjml/elements/head/mj_attributes.py
@@ -11,7 +11,7 @@ class MjAttributes(HeadComponent):
 
     def handler(self):
         add = self.context['add']
-        _children = self.props.children
+        _children = self.props.get("children")
 
         for child in _children:
             tagName = child['tagName']

--- a/mjml/elements/head/mj_breakpoint.py
+++ b/mjml/elements/head/mj_breakpoint.py
@@ -1,3 +1,6 @@
+import typing as t
+
+import typing_extensions as te
 
 from ._head_base import HeadComponent
 
@@ -6,14 +9,16 @@ __all__ = ['MjBreakpoint']
 
 
 class MjBreakpoint(HeadComponent):
-    component_name = 'mj-breakpoint'
+    component_name: t.ClassVar[str] = 'mj-breakpoint'
 
+    @te.override
     @classmethod
-    def allowed_attrs(cls):
+    def allowed_attrs(cls) -> t.Dict[str, str]:
         return {
             'width': 'unit(px)',
         }
 
-    def handler(self):
+    @te.override
+    def handler(self) -> None:
         add = self.context['add']
         add('breakpoint', self.getAttribute('width'))

--- a/mjml/elements/head/mj_font.py
+++ b/mjml/elements/head/mj_font.py
@@ -1,3 +1,6 @@
+import typing as t
+
+import typing_extensions as te
 
 from ._head_base import HeadComponent
 
@@ -6,15 +9,17 @@ __all__ = ['MjFont']
 
 
 class MjFont(HeadComponent):
-    component_name = 'mj-font'
+    component_name: t.ClassVar[str] = 'mj-font'
 
+    @te.override
     @classmethod
-    def allowed_attrs(cls):
+    def allowed_attrs(cls) -> t.Dict[str, str]:
         return {
             'href'            : 'string',
             'name'            : 'string',
         }
 
-    def handler(self):
+    @te.override
+    def handler(self) -> None:
         add = self.context['add']
         add('fonts', self.getAttribute('name'), self.getAttribute('href'))

--- a/mjml/elements/head/mj_head.py
+++ b/mjml/elements/head/mj_head.py
@@ -1,3 +1,6 @@
+import typing as t
+
+import typing_extensions as te
 
 from ._head_base import HeadComponent
 
@@ -5,7 +8,9 @@ from ._head_base import HeadComponent
 __all__ = ['MjHead']
 
 class MjHead(HeadComponent):
-    component_name = 'mj-head'
+    component_name: t.ClassVar[str] = 'mj-head'
 
-    def handler(self):
+    @te.override
+    def handler(self) -> t.Optional[str]:
+        # TODO typing: fix
         return self.handlerChildren()

--- a/mjml/elements/head/mj_html_attributes.py
+++ b/mjml/elements/head/mj_html_attributes.py
@@ -9,7 +9,7 @@ class MjHtmlAttributes(HeadComponent):
 
     def handler(self):
         add = self.context['add']
-        _children = self.props.children
+        _children = self.props.get("children")
 
         for child in _children:
             tagName = child['tagName']

--- a/mjml/elements/head/mj_html_attributes.py
+++ b/mjml/elements/head/mj_html_attributes.py
@@ -1,3 +1,6 @@
+import typing as t
+
+import typing_extensions as te
 
 from ._head_base import HeadComponent
 
@@ -5,9 +8,10 @@ from ._head_base import HeadComponent
 __all__ = ['MjHtmlAttributes']
 
 class MjHtmlAttributes(HeadComponent):
-    component_name = 'mj-html-attributes'
+    component_name: t.ClassVar[str] = 'mj-html-attributes'
 
-    def handler(self):
+    @te.override
+    def handler(self) -> None:
         add = self.context['add']
         _children = self.props.get("children")
 

--- a/mjml/elements/head/mj_preview.py
+++ b/mjml/elements/head/mj_preview.py
@@ -1,3 +1,6 @@
+import typing as t
+
+import typing_extensions as te
 
 from ._head_base import HeadComponent
 
@@ -6,8 +9,9 @@ __all__ = ['MjPreview']
 
 
 class MjPreview(HeadComponent):
-    component_name = 'mj-preview'
+    component_name: t.ClassVar[str] = 'mj-preview'
 
-    def handler(self):
+    @te.override
+    def handler(self) -> None:
         add = self.context['add']
         add('preview', self.getContent())

--- a/mjml/elements/head/mj_style.py
+++ b/mjml/elements/head/mj_style.py
@@ -1,3 +1,6 @@
+import typing as t
+
+import typing_extensions as te
 
 from ._head_base import HeadComponent
 
@@ -5,15 +8,17 @@ from ._head_base import HeadComponent
 __all__ = ['MjStyle']
 
 class MjStyle(HeadComponent):
-    component_name = 'mj-style'
+    component_name: t.ClassVar[str] = 'mj-style'
 
+    @te.override
     @classmethod
-    def default_attrs(cls):
+    def default_attrs(cls) -> t.Dict[str, str]:
         return {
             'inline': '',
         }
 
-    def handler(self):
+    @te.override
+    def handler(self) -> None:
         add = self.context['add']
         inline_attr = 'inlineStyle' if (self.get_attr('inline') == 'inline') else 'style'
         html_str = self.getContent()

--- a/mjml/elements/head/mj_title.py
+++ b/mjml/elements/head/mj_title.py
@@ -1,3 +1,6 @@
+import typing as t
+
+import typing_extensions as te
 
 from ._head_base import HeadComponent
 
@@ -5,8 +8,9 @@ from ._head_base import HeadComponent
 __all__ = ['MjTitle']
 
 class MjTitle(HeadComponent):
-    component_name = 'mj-title'
+    component_name: t.ClassVar[str] = 'mj-title'
 
-    def handler(self):
+    @te.override
+    def handler(self) -> None:
         add = self.context['add']
         add('title', self.getContent())

--- a/mjml/elements/mj_button.py
+++ b/mjml/elements/mj_button.py
@@ -124,7 +124,7 @@ class MjButton(BodyComponent):
         def _inner_padding(d):
             return self.getShorthandAttrValue('inner-padding', d, attr_with_direction=False)
         innerPaddings = _inner_padding('left') + _inner_padding('right')
-        borders = self.getBoxWidths().borders
+        borders = self.getBoxWidths().get("borders")
         width_int = parsedWidth - innerPaddings - borders
         return f'{width_int}px'
 

--- a/mjml/elements/mj_divider.py
+++ b/mjml/elements/mj_divider.py
@@ -63,7 +63,7 @@ class MjDivider(BodyComponent):
         parsedWidth, unit = widthParser(width)
 
         if unit == '%':
-            px = (parse_int(containerWidth) * parse_int(parsedWidth)) / 100 - paddingSize
+            px = (parse_int(containerWidth) * parsedWidth) / 100 - paddingSize
             return f'{px}px'
         elif unit == 'px':
             return width

--- a/mjml/elements/mj_section.py
+++ b/mjml/elements/mj_section.py
@@ -1,9 +1,7 @@
-
 import re
+import typing as t
 from collections import namedtuple
 from decimal import Decimal
-
-from dotmap import DotMap
 
 from ..helpers import parse_percentage, strip_unit, suffixCssClasses
 from ..lib import merge_dicts
@@ -19,7 +17,7 @@ class MjSection(BodyComponent):
     component_name = 'mj-section'
 
     @classmethod
-    def allowed_attrs(cls):
+    def allowed_attrs(cls) -> t.Dict[str, str]:
         return {
             'background-color' : 'color',
             'background-url'   : 'string',
@@ -136,7 +134,9 @@ class MjSection(BodyComponent):
 
     def getBackgroundString(self):
         bg_pos = self.getBackgroundPosition()
-        return f'{bg_pos.posX} {bg_pos.posY}'
+        x = bg_pos.get("posX")
+        y = bg_pos.get("posY")
+        return f'{x} {y}'
 
     def getChildContext(self):
         box = self.getBoxWidths()['box']
@@ -188,12 +188,12 @@ class MjSection(BodyComponent):
             self.renderAfter()
         ])
 
-    def getBackgroundPosition(self):
+    def getBackgroundPosition(self) -> t.Dict[str, t.Any]:
         pos = self.parseBackgroundPosition()
-        return DotMap({
+        return {
             'posX': self.getAttribute('background-position-x') or pos.x,
             'posY': self.getAttribute('background-position-y') or pos.y,
-        })
+        }
 
     def parseBackgroundPosition(self):
         posSplit = self.getAttribute('background-position').split(' ')
@@ -337,8 +337,16 @@ class MjSection(BodyComponent):
             vY = 0
         else:
             bgPos = self.getBackgroundPosition()
-            bgPosX = self._get_bg_percentage(bgPos.posX, ('left', 'center', 'right'), default='50%')
-            bgPosY = self._get_bg_percentage(bgPos.posY, ('top', 'center', 'bottom'), default='0%')
+            bgPosX = self._get_bg_percentage(
+                bgPos.get("posX"),
+                ('left', 'center', 'right'),
+                default='50%'
+            )
+            bgPosY = self._get_bg_percentage(
+                bgPos.get("posY"),
+                ('top', 'center', 'bottom'),
+                default='0%'
+            )
             # this logic is different when using repeat or no-repeat
             vX = self._calc_origin_pos_value(is_x=True, bg_pos=bgPosX)
             vY = self._calc_origin_pos_value(is_x=False, bg_pos=bgPosY)

--- a/mjml/helpers/py_utils.py
+++ b/mjml/helpers/py_utils.py
@@ -1,5 +1,5 @@
-
 import re
+import typing as t
 from decimal import Decimal
 
 
@@ -15,6 +15,8 @@ __all__ = [
     'strip_unit',
 ]
 
+
+# TODO typing: figure out types
 def omit(attributes, keys):
     if isinstance(keys, str):
         keys = (keys, )
@@ -24,36 +26,39 @@ def omit(attributes, keys):
             _attrs.pop(key)
     return _attrs
 
-def parse_float(value_str):
-    match = re.search(r'^([-+]?\d+(.\d+)?)*', value_str)
+def parse_float(value: str) -> float:
+    if (match := re.search(r'^([-+]?\d+(.\d+)?)*', value)) is None:
+        raise ValueError(f"could not parse float from '{value}'")
     return float(match.group(1))
 
-def parse_int(value_str):
-    if isinstance(value_str, int):
-        return value_str
-    match = re.search(r'^([-+]?\d+)*', value_str)
+def parse_int(value: str) -> int:
+    if (match := re.search(r'^([-+]?\d+)*', value)) is None:
+        raise ValueError(f"could not parse int from '{value}'")
     return int(match.group(1))
 
-def parse_percentage(value_str):
-    match = re.search(r'^(\d+(\.\d+)?)%$', value_str)
+def parse_percentage(value: str) -> Decimal:
+    if (match := re.search(r'^(\d+(\.\d+)?)%$', value)) is None:
+        raise ValueError(f"could not parse decimal from '{value}'")
     return Decimal(match.group(1))
 
-def strip_unit(value_str):
-    match = re.search(r'^(\d+).*', value_str)
+# TODO: fix if this should support decimals/floats as well
+def strip_unit(value: str) -> int:
+    if (match := re.search(r'^(\d+).*', value)) is None:
+        raise ValueError(f"could not strip unit from '{value}'")
     return int(match.group(1))
 
-def is_nil(v):
+def is_nil(v: t.Optional[t.Any]) -> bool:
     return (v is None)
 
-def is_not_nil(v):
+def is_not_nil(v: t.Optional[t.Any]) -> bool:
     return not is_nil(v)
 
-def is_empty(v):
+def is_empty(v: t.Optional[t.Sequence[t.Any]]) -> bool:
     if v is None:
         return True
     elif hasattr(v, 'strip'):
         return not bool(v.strip())
     return not bool(v)
 
-def is_not_empty(v):
+def is_not_empty(v: t.Optional[t.Sequence[t.Any]]) -> bool:
     return not is_empty(v)

--- a/mjml/helpers/shorthand_parser.py
+++ b/mjml/helpers/shorthand_parser.py
@@ -5,7 +5,7 @@ from .py_utils import parse_int
 
 
 if t.TYPE_CHECKING:
-    _Direction = t.Literal["top", "bottom", "left", "right"]
+    from mjml._types import _Direction
 
 
 __all__ = ['shorthandParser', 'borderParser']

--- a/mjml/helpers/shorthand_parser.py
+++ b/mjml/helpers/shorthand_parser.py
@@ -1,12 +1,16 @@
-
 import re
+import typing as t
 
 from .py_utils import parse_int
 
 
+if t.TYPE_CHECKING:
+    _Direction = t.Literal["top", "bottom", "left", "right"]
+
+
 __all__ = ['shorthandParser', 'borderParser']
 
-def shorthandParser(cssValue, direction):
+def shorthandParser(cssValue: str, direction: "_Direction") -> int:
     splittedCssValue = cssValue.split(' ')
 
     top    = 0
@@ -29,11 +33,11 @@ def shorthandParser(cssValue, direction):
 
     directions = {'top': top, 'bottom': bottom, 'left': left, 'right': right}
 
-    value_int = splittedCssValue[directions[direction]] or 0
+    value_int = splittedCssValue[directions[direction]] or "0"
     return parse_int(value_int)
 
 
-def borderParser(border):
+def borderParser(border: str) -> int:
     border_regex = re.compile(r'(?:(?:^| )(\d+))')
     match = border_regex.search(border)
     # Upstream does not have to deal with this case as "parseInt(undefined, 10)"

--- a/mjml/lib/dict_merger.py
+++ b/mjml/lib/dict_merger.py
@@ -1,25 +1,26 @@
 # -*- coding: UTF-8 -*-
 # Copyright 2015 Felix Schwarz
 # The source code in this file is licensed under the MIT license.
+import typing as t
 
 
-__all__ = ['merge_dicts']
+__all__ = ["merge_dicts"]
 
-def merge_dicts(*sources):
+def merge_dicts(*sources: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
     # initial code from
     #    Robin Bryce, Tue, 19 Dec 2006
     #    PSF license
     #    http://code.activestate.com/recipes/499335-recursively-update-a-dictionary-without-hitting-py/
-    result = {}
+    result: t.Dict[str, t.Any] = {}
     for source in sources:
         stack = [(source, result)]
         while stack:
             current_src, current_dst = stack.pop()
             for key in (current_src or ()):
-                src_item_is_dict = isinstance(current_src.get(key), dict)
-                dst_item_is_dict = isinstance(current_dst.get(key), dict)
-                if src_item_is_dict and dst_item_is_dict:
-                    stack.append((current_src[key], current_dst[key]))
+                src_item = current_src.get(key)
+                dst_item = current_dst.get(key)
+                if isinstance(src_item, dict) and isinstance(dst_item, dict):
+                    stack.append((src_item, dst_item))
                 else:
-                    current_dst[key] = current_src[key]
+                    current_dst[key] = src_item
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,16 @@ src = ["mjml", "tests"]
 lines-after-imports = 2
 known-first-party = ["mjml"]
 combine-as-imports = true
+
+
+[tool.mypy]
+python_version = "3.8"
+# strict = true
+warn_unused_configs = true
+warn_unused_ignores = true
+check_untyped_defs = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_no_return = true
+warn_unreachable = true
+warn_incomplete_stub = true


### PR DESCRIPTION
The goal of this branch is to add complete typing to the package, for two main reasons:
1. improve developer experience for consumers of this package
2. catch bugs (while working on this package) that a type checker would've caught

I've started to do some exploration within the code base, with the initial goal to pass [mypy][mypy] checks in non-strict mode, and the ultimate goal to satisfy mypy in strict mode. There's a GitHub Actions workflow for tracking progress in that regard.

Some downsides:
- This restricts the minimum Python version to 3.8, although this shouldn't be a big issue, considering [Python 3.7 is EOL as of mid-2023][pyv].
- In order to support Python 3.8, the typing is restricted to the 3.8 style, which is a bit more limited than with newer versions, but that's not really a problem.
- The dependency on [dotmap][dotmap] had to be replaced with standard `dict`s, at least temporarily, in order to avoid a bunch of `# type: ignore` comments. It may be possible to re-introduce it (or another similar package) once the type check passes.

Let me know if you're interested in me pursuing this goal!


[mypy]: https://mypy.readthedocs.io/en/stable/
[pyv]: https://devguide.python.org/versions/
[dotmap]: https://pypi.org/project/dotmap/