### PR TITLE
Stubs for public interface

### DIFF
--- a/mjml/__init__.pyi
+++ b/mjml/__init__.pyi
@@ -1,0 +1,21 @@
+import pathlib
+import typing as t
+
+if t.TYPE_CHECKING:
+    from _typeshed import SupportsRead
+
+    from mjml.core.api import Component
+
+    class _Output(t.NamedTuple):
+        html: str
+        errors: t.Sequence[str]
+
+    FpOrJson = t.Union[t.Dict[str, t.Any], str, bytes, SupportsRead[str], SupportsRead[bytes]]
+    StrOrPath = t.Union[str, pathlib.PurePath]
+
+def mjml_to_html(
+    xml_fp_or_json: "FpOrJson",
+    skeleton: t.Optional[str] = None,
+    template_dir: t.Optional["StrOrPath"] = None,
+    custom_components: t.Optional[t.List[t.Type["Component"]]] = None,
+) -> "_Output": ...

--- a/mjml/__init__.pyi
+++ b/mjml/__init__.pyi
@@ -23,7 +23,7 @@ if t.TYPE_CHECKING:
         @te.overload
         def get(self, key: t.Literal["errors"], default: t.Sequence[str], /) -> t.Sequence[str]: ...
 
-    FpOrJson = t.Union[t.Dict[str, t.Any], str, bytes, SupportsRead[str], SupportsRead[bytes]]
+    FpOrJson = t.Union[t.Mapping[str, t.Any], str, bytes, SupportsRead[str], SupportsRead[bytes]]
 
 def mjml_to_html(
     xml_fp_or_json: "FpOrJson",

--- a/mjml/__init__.pyi
+++ b/mjml/__init__.pyi
@@ -2,6 +2,7 @@ import pathlib
 import typing as t
 
 if t.TYPE_CHECKING:
+    import typing_extensions as te
     from _typeshed import SupportsRead
 
     from mjml.core.api import Component
@@ -9,6 +10,19 @@ if t.TYPE_CHECKING:
     class _Output(t.NamedTuple):
         html: str
         errors: t.Sequence[str]
+
+        @te.overload
+        def __getitem__(self, _: t.Literal["html"]) -> str: ...
+        @te.overload
+        def __getitem__(self, _: t.Literal["errors"]) -> t.Sequence[str]: ...
+        @te.overload
+        def get(self, key: t.Literal["html"], /) -> t.Optional[str]: ...
+        @te.overload
+        def get(self, key: t.Literal["html"], default: str, /) -> str: ...
+        @te.overload
+        def get(self, key: t.Literal["errors"], /) -> t.Optional[t.Sequence[str]]: ...
+        @te.overload
+        def get(self, key: t.Literal["errors"], default: t.Sequence[str], /) -> t.Sequence[str]: ...
 
     FpOrJson = t.Union[t.Dict[str, t.Any], str, bytes, SupportsRead[str], SupportsRead[bytes]]
     StrOrPath = t.Union[str, pathlib.PurePath]

--- a/mjml/__init__.pyi
+++ b/mjml/__init__.pyi
@@ -1,9 +1,8 @@
-import pathlib
 import typing as t
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
-    from _typeshed import SupportsRead
+    from _typeshed import StrPath, SupportsRead
 
     from mjml.core.api import Component
 
@@ -25,11 +24,10 @@ if t.TYPE_CHECKING:
         def get(self, key: t.Literal["errors"], default: t.Sequence[str], /) -> t.Sequence[str]: ...
 
     FpOrJson = t.Union[t.Dict[str, t.Any], str, bytes, SupportsRead[str], SupportsRead[bytes]]
-    StrOrPath = t.Union[str, pathlib.PurePath]
 
 def mjml_to_html(
     xml_fp_or_json: "FpOrJson",
     skeleton: t.Optional[str] = None,
-    template_dir: t.Optional["StrOrPath"] = None,
+    template_dir: t.Optional["StrPath"] = None,
     custom_components: t.Optional[t.List[t.Type["Component"]]] = None,
 ) -> "_Output": ...


### PR DESCRIPTION
This is a minimal PR, which (mostly) resolves #50, as discussed in #57.

For overriding components in downstream projects, the public interface of all components should be typed accordingly, but I'll leave that for the next PR (unless it's seen as pertinent to do here while we're at it).

For instance, calls like this:
https://github.com/FelixSchwarz/mjml-python/blob/ed3187e2d7f22ab39848f056e7406ef0b2118aff/tests/custom_components_test.py#L28-L31

...will cause mypy to error with:
```
error: Call to untyped function "render" in typed context  [no-untyped-call]
```

The same goes for e.g. `default_attrs` and so on, so type annotations should be added to these as soon as possible.