### PR TITLE
Replace 'docopt' with 'docopt-ng' in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     beautifulsoup4 < 4.13; python_version <= '3.6'
     beautifulsoup4; python_version > '3.6'
     dotmap
-    docopt
+    docopt-ng
     jinja2
 
 scripts =


### PR DESCRIPTION
docopt appears abandoned; docopt-ng is intended to be kept up to date, while remaining functionally compatible